### PR TITLE
change to public and open communication

### DIFF
--- a/index.html
+++ b/index.html
@@ -456,7 +456,7 @@ that will serve as input for this document.</p>
         </h2>
         <p id="public">
           Technical discussions for this Working Group are conducted in <a href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed on a public repository, and may permit direct public contribution requests.
-        The meetings themselves are not open to public participation, however.
+        The meetings themselves <i>will</i> be open to public participation.
         </p>
         <p>
           Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="https://www.w3.org/2019/did-wg/">Decentralized Identifier Working Group home page.</a>


### PR DESCRIPTION
So, my issue with this working group charter has to do with it's exclusivity to only members of the W3C after it is created.  

If this is proposed as a working group for the W3C then it should remain open to community input rather than a members' only effort.  

It is my belief that the work of Decentralized Identifiers (the DID spec) extends beyond just the http protocol and should take input from other standards bodies that are also working on this.
(disclosure: I am the chair of the IEEE p2418.6 Identity in Healthcare working group)

My vision of the use-case for DIDs really echos what I imagine was the motivation of @timbl in creating the world wide web in the first place. That anyone could spin up a computer under their desk, be a valid node on the internet and serve up some pages of information.  Somehow along the way of realizing this vision, the practicalities of running your own server 24/7 has led to massive centralization.  In that same vein, today anyone should be able to create their own random number and associate their identity (just a bunch of claims) to it without a middle man (large company) or organization like the doi Foundation and other rent-seeking entities. 

Enabling personal control over the cryptographic keys linked to my decentralized identifier is critical infrastructure to the future of data-ownership and towards data-democratization.  

Companies WILL have an important role as being stewards of our identity, just as banks are now realizing that their customers can store your money anywhere … but who do you trust with your identity? 

This new technology shouldn't be developed to only a few companies (the 800 pound gorillas) that would dictate the specification to continue to maintain control over our data in massive data lakes that are inaccessible to us mere mortals. 

That paradigm is what has enabled Russian hackers to meddle with the 2016 election, the Facebook-Cambridge Analytica scandal and the Equifax failure. 

In many respects, the proposed state is just another wolf in sheep’s clothing (DIDs under the guise of self-sovereignty).  

@timbl, What happened to "This Is For Everyone!" ? (queue dramatic music) 
