### PR TITLE
Change language to not disallow DIDs based on centralized authorities

### DIFF
--- a/index.html
+++ b/index.html
@@ -137,8 +137,8 @@ benefits over more traditional URLs:
 
         <ul>
           <li>
-DIDs are controlled by individuals, organizations, and machines, not leased from
-an authority (e.g. DNS Registrars).
+DIDs may be controlled by individuals, organizations, and machines, so they are not required to be dependent on
+an external authority (e.g. DNS Registrars).
           </li>
           <li>
 The controller of a DID can cryptographically authenticate themselves


### PR DESCRIPTION
There are different schools of thought on this topic, which is being discussed during the Thursday DID specification discussions. In one of these, the DID specification wouldn't _preclude_ DID methods based on centralized authorities. This change reflects that, and is intended to address https://github.com/w3c-ccg/did-wg-charter/issues/16.

(Created during working session with @burnburn and @talltree.)