### PR TITLE
Address concern around finality of use cases

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@ Recommend a way of authoring specifications for DID Methods and protocols
 that are conformant with the data model and syntax(es).
           </li>
           <li>
-Concentrate their efforts on the developed <a href="https://w3c-ccg.github.io/did-use-cases/">use cases</a>
+Concentrate their efforts on the initial <a href="https://w3c-ccg.github.io/did-use-cases/">use cases</a>
 with a particular focus on Identity and Access Management. Use cases from
 other industries may be included if there is significant industry participation.
           </li>

--- a/index.html
+++ b/index.html
@@ -169,7 +169,7 @@ The <strong>mission</strong> of the
 <a href="https://www.w3.org/2019/did-wg/">Decentralized Identifier Working Group</a>
 is to standardize the data model and syntax of Decentralized Identifier
 Documents, which contain information related to DIDs that enable the
-aforementioned use cases.</p>
+aforementioned initual use cases.</p>
 
       <div class="noprint"> <p class="join"><a class="todo" href="https://www.w3.org/2004/01/pp-impl/#####/join">Join the Decentralized Identifier Working Group.</a></p>
       </div>
@@ -237,8 +237,7 @@ Recommend a way of authoring specifications for DID Methods and protocols
 that are conformant with the data model and syntax(es).
           </li>
           <li>
-Concentrate their efforts on the identified
-<a href="https://w3c-ccg.github.io/did-use-cases/">use cases</a>
+Concentrate their efforts on the developed <a href="https://w3c-ccg.github.io/did-use-cases/">use cases</a>
 with a particular focus on Identity and Access Management. Use cases from
 other industries may be included if there is significant industry participation.
           </li>
@@ -350,7 +349,7 @@ The Working Group will develop a set of use cases and requirements to underpin
 its work. Abstract use cases will be supported by real world evidence of
 applicability. The
 <a href="https://www.w3.org/community/credentials/">Credentials Community Group</a>
-has developed a set of
+has developed a set of initial 
 <a href="https://w3c-ccg.github.io/did-use-cases/">use cases and requirements</a>
 that will serve as input for this document.</p>
               </p>

--- a/index.html
+++ b/index.html
@@ -244,6 +244,9 @@ Concentrate their efforts on the initial <a href="https://w3c-ccg.github.io/did-
 with a particular focus on Identity and Access Management. Use cases from
 other industries may be included if there is significant industry participation.
           </li>
+          <li>
+With the initial <a href="https://w3c-ccg.github.io/did-use-cases/">use cases</a> document as input, the WG will produce a NOTE at the end of the process that is a refined Use Cases document.
+          </li>
         </ol>
 
         <div id="section-out-of-scope">

--- a/index.html
+++ b/index.html
@@ -169,7 +169,7 @@ The <strong>mission</strong> of the
 <a href="https://www.w3.org/2019/did-wg/">Decentralized Identifier Working Group</a>
 is to standardize the data model and syntax of Decentralized Identifier
 Documents, which contain information related to DIDs that enable the
-aforementioned initual use cases.</p>
+aforementioned initial use cases.</p>
 
       <div class="noprint"> <p class="join"><a class="todo" href="https://www.w3.org/2004/01/pp-impl/#####/join">Join the Decentralized Identifier Working Group.</a></p>
       </div>


### PR DESCRIPTION
This is an attempt to address https://github.com/w3c-ccg/did-wg-charter/issues/9.

We believe the concern is that the [current set of DID use cases](https://w3c-ccg.github.io/did-use-cases/) is final and inflexible. 

The language change in this PR is intended to address this concern by clarifying that the referenced DID use cases are only meant to be a starting point. 

We understand and agree that use cases are an output of the DID WG (we confirmed they are listed as such in the draft charter.)

(Created during working session with @burnburn and @talltree.)