### PR TITLE
Update language: DIDs enable cryptographic authentication

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@ DIDs are controlled by individuals, organizations, and machines, not leased from
 an authority (e.g. DNS Registrars).
           </li>
           <li>
-DIDs enable the controller of a DID to cryptographically authenticate themselves
+DIDs enable cryptographic authentication of a DID controller
 (e.g. DID-based website login using a WebAuthn/FIDO token).
           </li>
           <li>

--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@ an authority (e.g. DNS Registrars).
           </li>
           <li>
 DIDs enable the controller of a DID to cryptographically authenticate themselves
-(e.g. DID-based website login).
+(e.g. DID-based website login using a WebAuthn/FIDO token).
           </li>
           <li>
 DIDs provide discovery information for bootstrapping into more secure and

--- a/index.html
+++ b/index.html
@@ -141,8 +141,8 @@ DIDs are controlled by individuals, organizations, and machines, not leased from
 an authority (e.g. DNS Registrars).
           </li>
           <li>
-The controller of a DID can cryptographically authenticate themselves
-(e.g. DID-based website login) .
+DIDs enable the controller of a DID to cryptographically authenticate themselves
+(e.g. DID-based website login).
           </li>
           <li>
 DIDs provide discovery information for bootstrapping into more secure and


### PR DESCRIPTION
Update language to indicate this scenario is enabled
"The controller of a DID can cryptographically authenticate themselves (e.g. DID-based website login)."

Addresses #17 
