### PR TITLE
DID method implementation is out of scope

### DIFF
--- a/index.html
+++ b/index.html
@@ -301,7 +301,7 @@ Authentication or Authorization Protocols
 Browser APIs
               </li>
               <li>
-Specific Implementations of DID Methods and Protocols  Specific DID Method specifications or Protocol specifications
+Specific DID Method specifications or Protocol specifications
               </li>
               <li>
 "Solving Identity" on the Web

--- a/index.html
+++ b/index.html
@@ -163,6 +163,10 @@ useful. There are also a set of
 that have been curated by the various organizations implementing and deploying
 this technology in commercial environments.
       </p>
+      
+      <p>
+      The pattern for the DID spec is the URI spec (RFC 3986). That spec defines the generic syntax for URIs, and all URI schemes are separate specs (in fact, the DID spec is one of those specs, i.e., a fully RFC 3986 conformant URI scheme). The goal of the DID spec is to do exactly the same for DIDs, i.e., for this WG to define the generic DID spec, and then for others to define DID method specs.
+      </p>
 
       <p class="mission">
 The <strong>mission</strong> of the
@@ -256,6 +260,7 @@ addressed by this Working Group.
               <li>Browser APIs</li>
               <li>Specific Implementations of DID Methods and Protocols</li>
               <li>"Solving Identity" on the Web</li>
+              <li>Defining a concrete DID method implementation</li>
             </ul>
         </div>
 


### PR DESCRIPTION
Clarify that publishing a specific DID method implementation is out of scope, and that the DID specification is modeled after the URI spec (RFC 3986)

Addresses #21.