### PR TITLE
DIDs are not always controlled by the subject.

### DIFF
--- a/index.html
+++ b/index.html
@@ -356,7 +356,7 @@ The Decentralized Identifier Working Group will deliver the following W3C normat
             <dd>
               <p>
 Decentralized Identifiers (DIDs) are a new type of identifier for verifiable,
-decentralized digital identity, fully under the control of the DID
+decentralized digital identity, typically under the control of the DID
 subject, and independent of any centralized registry, identity provider, or
 certificate authority. DIDs are URLs that relate a DID subject to means for
 trustable interactions with that subject. DIDs resolve to DID Documents &mdash;


### PR DESCRIPTION
This fixes #20.

The other two changes that the issue submitter requested were not applied because:

* A DID Document contains verification methods (such as public keys) for verifying exchanges of digital information.
* A verification of a digital signature is a "trustable interaction"
